### PR TITLE
Add proper timestamp support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,13 @@ dependencies = [
 [[package]]
 name = "discord-rpc-client"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b176996f649824caad056133be782350e287687a5cae43636215f6b153bac481"
+replace = "discord-rpc-client 0.3.0 (git+https://github.com/JakeStanger/discord-rpc-client.rs)"
+
+[[package]]
+name = "discord-rpc-client"
+version = "0.3.0"
 source = "git+https://github.com/JakeStanger/discord-rpc-client.rs#e14a4368ce7b4195df87e209b04ade36d89b7c6a"
 dependencies = [
  "byteorder",
@@ -161,13 +168,6 @@ dependencies = [
  "serde_json",
  "uuid",
 ]
-
-[[package]]
-name = "discord-rpc-client"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b176996f649824caad056133be782350e287687a5cae43636215f6b153bac481"
-replace = "discord-rpc-client 0.3.0 (git+https://github.com/JakeStanger/discord-rpc-client.rs)"
 
 [[package]]
 name = "fuchsia-cprng"

--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ I have a derivation on the way. The `[replace]` tag is causing some issues right
 Running the program once will generate a default configuration file. On Linux this will be at `~/.config/discord-rpc/config.toml`
 
 - **id** - The Discord application ID to run through. 
-- **hosts** - An array of MPD server host socket addresses. Each one will be tried in order until a playing server is found.
+- **hosts** - An array of MPD server host socket addresses. 
+    Each one will be tried in order until a playing server is found.
 - **format** - Format strings. Tokens are listed below.
-    - **details** - A format string for the top line. This is the song title by default.
-    - **state** - A format string for the second line. This is the artist / album by default.
+    - **details** - A format string for the top line. 
+        This is the song title by default.
+    - **state** - A format string for the second line. 
+        This is the artist / album by default.
+    - **timestamp** - The timestamp mode for the third line. 
+        This is 'elapsed' by default.
+        Can be one of `elapsed`, `left` or `off`. Falls back to `elapsed`.
 
 ### Formatting Tokens
 
@@ -70,4 +76,5 @@ hosts = ["localhost:6600"]
 [format]
 details = "$title"
 state = "$artist / $album"
+timestamp = "elapsed"
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::defaults::{DEFAULT_HOST, DETAILS_FORMAT, DISCORD_ID, STATE_FORMAT};
+use crate::defaults::{DEFAULT_HOST, DETAILS_FORMAT, DISCORD_ID, STATE_FORMAT, TIMESTAMP_MODE};
 use dirs::config_dir;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -9,6 +9,8 @@ use std::path::Path;
 pub struct Format {
     pub(crate) details: String,
     pub(crate) state: String,
+     // 'elapsed', 'left', or 'off'. optional as new feat
+    pub(crate) timestamp: Option<String>
 }
 
 #[derive(Serialize, Deserialize)]
@@ -33,6 +35,7 @@ impl Config {
             format: Some(Format {
                 details: DETAILS_FORMAT.to_string(),
                 state: STATE_FORMAT.to_string(),
+                timestamp: Some(TIMESTAMP_MODE.to_string())
             }),
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 pub struct Format {
     pub(crate) details: String,
     pub(crate) state: String,
-     // 'elapsed', 'left', or 'off'. optional as new feat
-    pub(crate) timestamp: Option<String>
+    // 'elapsed', 'left', or 'off'. optional as new feat
+    pub(crate) timestamp: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -35,7 +35,7 @@ impl Config {
             format: Some(Format {
                 details: DETAILS_FORMAT.to_string(),
                 state: STATE_FORMAT.to_string(),
-                timestamp: Some(TIMESTAMP_MODE.to_string())
+                timestamp: Some(TIMESTAMP_MODE.to_string()),
             }),
         };
 

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -6,3 +6,4 @@ pub const DEFAULT_HOST: &str = "localhost:6600";
 
 pub const DETAILS_FORMAT: &str = "$title";
 pub const STATE_FORMAT: &str = "$artist / $album";
+pub const TIMESTAMP_MODE: &str = "elapsed";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,14 @@ mod config;
 mod defaults;
 mod mpd_conn;
 
+use crate::defaults::TIMESTAMP_MODE;
+use crate::mpd_conn::get_timestamp;
 use config::Config;
 use defaults::{ACTIVE_TIME, DETAILS_FORMAT, IDLE_TIME, STATE_FORMAT};
 use discord_rpc_client::Client as DiscordClient;
 use mpd::{Client as MPDClient, Song, State};
 use regex::{Captures, Regex};
 use std::{thread, time};
-use crate::mpd_conn::get_timestamp;
-use crate::defaults::TIMESTAMP_MODE;
 
 /// Attempts to find a playing MPD host every 5
 /// seconds until one is found

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,22 +38,16 @@ fn main() {
 
     let format_options = config.format;
 
-    let details_format = match format_options.as_ref() {
-        Some(options) => options.details.as_str(),
-        None => DETAILS_FORMAT,
-    };
-
-    let state_format = match format_options.as_ref() {
-        Some(options) => options.state.as_str(),
-        None => STATE_FORMAT,
-    };
-
-    let timestamp_mode = match format_options.as_ref() {
-        Some(options) => match options.timestamp.as_ref() {
-            Some(t) => t.as_str(),
-            None => TIMESTAMP_MODE
-        },
-        None => TIMESTAMP_MODE
+    let (details_format, state_format, timestamp_mode) = match format_options.as_ref() {
+        Some(opt) => (
+            opt.details.as_str(),
+            opt.state.as_str(),
+            opt.timestamp
+                .as_ref()
+                .map(String::as_str)
+                .unwrap_or(TIMESTAMP_MODE),
+        ),
+        None => (DETAILS_FORMAT, STATE_FORMAT, TIMESTAMP_MODE),
     };
 
     // MPD and Discord connections

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -1,7 +1,6 @@
+use discord_rpc_client::models::ActivityTimestamps;
 use mpd::{Client as MPDClient, Song, State};
 use std::time::{SystemTime, UNIX_EPOCH};
-use discord_rpc_client::models::ActivityTimestamps;
-
 
 /// Cycles through each MPD host and
 /// returns the first one which is playing,
@@ -46,16 +45,24 @@ pub(crate) fn get_token_value(client: &mut MPDClient, song: &Song, token: &str) 
     s.cloned().unwrap_or_default()
 }
 
-pub(crate) fn get_timestamp(client: &mut MPDClient, timestamps: ActivityTimestamps, mode: &str) -> ActivityTimestamps {
-    let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+pub(crate) fn get_timestamp(
+    client: &mut MPDClient,
+    timestamps: ActivityTimestamps,
+    mode: &str,
+) -> ActivityTimestamps {
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
     let status = client.status().unwrap();
 
     match mode {
         "left" => {
-            let remaining = status.duration.unwrap().num_seconds() - status.elapsed.unwrap().num_seconds();
-        timestamps.end(current_time + remaining as u64)
-        },
+            let remaining =
+                status.duration.unwrap().num_seconds() - status.elapsed.unwrap().num_seconds();
+            timestamps.end(current_time + remaining as u64)
+        }
         "off" => timestamps,
-        _ =>  timestamps.start(current_time - status.elapsed.unwrap().num_seconds() as u64)
+        _ => timestamps.start(current_time - status.elapsed.unwrap().num_seconds() as u64),
     }
 }

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -1,4 +1,7 @@
 use mpd::{Client as MPDClient, Song, State};
+use std::time::{SystemTime, UNIX_EPOCH};
+use discord_rpc_client::models::ActivityTimestamps;
+
 
 /// Cycles through each MPD host and
 /// returns the first one which is playing,
@@ -41,4 +44,18 @@ pub(crate) fn get_token_value(client: &mut MPDClient, song: &Song, token: &str) 
         _ => return token.to_string(),
     };
     s.cloned().unwrap_or_default()
+}
+
+pub(crate) fn get_timestamp(client: &mut MPDClient, timestamps: ActivityTimestamps, mode: &str) -> ActivityTimestamps {
+    let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let status = client.status().unwrap();
+
+    match mode {
+        "left" => {
+            let remaining = status.duration.unwrap().num_seconds() - status.elapsed.unwrap().num_seconds();
+        timestamps.end(current_time + remaining as u64)
+        },
+        "off" => timestamps,
+        _ =>  timestamps.start(current_time - status.elapsed.unwrap().num_seconds() as u64)
+    }
 }


### PR DESCRIPTION
Discord's proper timestamp feature is now leveraged to display either the elapsed or remaining time on a new line.

```toml
[format]
# ...
timestamp = "elapsed"
```
This can be one of `elapsed`, `left` or `off`. It will default to `elapsed` if the value does not match one of the options, or the key is not present.

Resolves #6 which is caused by limitations in the RPC client.