### PR TITLE
Error handling improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,9 @@ fn idle(hosts: &[String]) -> MPDClient {
     loop {
         let conn_wrapper = mpd_conn::try_get_mpd_conn(hosts);
 
-        if conn_wrapper.is_some() {
+        if let Some(client) = conn_wrapper {
             println!("Exiting idle mode");
-            return conn_wrapper.unwrap();
+            return client;
         }
 
         thread::sleep(time::Duration::from_secs(IDLE_TIME));

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,11 @@ fn main() {
                     .assets(|asset| asset.small_image("notes"))
                     .timestamps(|timestamps| get_timestamp(&mut mpd, timestamps, timestamp_mode))
             }) {
-                println!("Failed to set activity: {}", why);
+                eprintln!("Failed to set activity: {}", why);
             };
         } else {
             if let Err(why) = drpc.clear_activity() {
-                println!("Failed to clear activity: {}", why);
+                eprintln!("Failed to clear activity: {}", why);
             };
 
             mpd = idle(hosts);

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -7,11 +7,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// or none if one is not found.
 pub(crate) fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
     for host in hosts {
-        if let Ok(mut conn) = MPDClient::connect(host) {
-            let state = conn.status().unwrap().state;
-            if state == State::Play {
-                return Some(conn);
+        match MPDClient::connect(host) {
+            Ok(mut conn) => {
+                let state = conn.status().unwrap().state;
+                if state == State::Play {
+                    return Some(conn);
+                }
             }
+            Err(why) => eprintln!("Error connecting to {}: {}", host, why),
         }
     }
 


### PR DESCRIPTION
This changes `try_get_mpd_conn` to print connection errors instead of ignoring them. I also removed an unnecessary unwrap in the `idle` function and made all error messages be printed to stderr.