### PR TITLE
Added config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.vscode

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Running the program once will generate a default configuration file. On Linux th
     - **timestamp** - The timestamp mode for the third line. 
         This is 'elapsed' by default.
         Can be one of `elapsed`, `left` or `off`. Falls back to `elapsed`.
+    - **large_image** - The name of the rich presence asset that gets displayed as the large image. This is `"notes"` by default. Setting this to `""` disables the large image.
+    - **small_image** - The name of the rich presence asset that gets displayed as the small image. This is `"notes"` by default. Setting this to `""` disables the small image.
+    - **large_text** - A format string that is displayed upon hovering the large image. Setting this to `""` disables the hover.
+    - **small_text** - A format string that is displayed upon hovering the small image. Setting this to `""` disables the hover.
 
 ### Formatting Tokens
 
@@ -77,4 +81,8 @@ hosts = ["localhost:6600"]
 details = "$title"
 state = "$artist / $album"
 timestamp = "elapsed"
+large_image = "notes"
+small_image = "notes"
+large_text = ""
+small_text = ""
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,14 @@
-use crate::defaults::{DEFAULT_HOST, DETAILS_FORMAT, DISCORD_ID, STATE_FORMAT, TIMESTAMP_MODE};
+use crate::defaults::{
+    DEFAULT_HOST,
+    DETAILS_FORMAT,
+    DISCORD_ID,
+    STATE_FORMAT,
+    TIMESTAMP_MODE,
+    LARGE_IMAGE,
+    SMALL_IMAGE,
+    LARGE_TEXT,
+    SMALL_TEXT,
+};
 use dirs::config_dir;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -11,6 +21,10 @@ pub struct Format {
     pub(crate) state: String,
     // 'elapsed', 'left', or 'off'. optional as new feat
     pub(crate) timestamp: Option<String>,
+    pub(crate) large_image: String,
+    pub(crate) small_image: String,
+    pub(crate) large_text: String,
+    pub(crate) small_text: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -36,6 +50,10 @@ impl Config {
                 details: DETAILS_FORMAT.to_string(),
                 state: STATE_FORMAT.to_string(),
                 timestamp: Some(TIMESTAMP_MODE.to_string()),
+                large_image: LARGE_IMAGE.to_string(),
+                small_image: SMALL_IMAGE.to_string(),
+                large_text: LARGE_TEXT.to_string(),
+                small_text: SMALL_TEXT.to_string(),
             }),
         };
 
@@ -48,7 +66,7 @@ impl Config {
         let path = config_dir().unwrap().join(Path::new("discord-rpc"));
         let filename = "config.toml";
 
-        if !path.exists() {
+        if !path.join(filename).exists() {
             Config::create(&path, filename).expect("Failed to create config file");
         }
 

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -7,3 +7,7 @@ pub const DEFAULT_HOST: &str = "localhost:6600";
 pub const DETAILS_FORMAT: &str = "$title";
 pub const STATE_FORMAT: &str = "$artist / $album";
 pub const TIMESTAMP_MODE: &str = "elapsed";
+pub const LARGE_IMAGE: &str = "notes";
+pub const SMALL_IMAGE: &str = "notes";
+pub const LARGE_TEXT: &str = "";
+pub const SMALL_TEXT: &str = "";


### PR DESCRIPTION
Added the config options `large_image` and `small_image` for choosing the name of the rich presence asset that gets displayed as the corresponding image. This enables displaying two different images or disabling them by setting keys to `""`.

Also added the config options `large_text` and `small_text` with format strings that get displayed upon hovering the corresponding image. They can be disabled by setting the keys to `""`.

Closes #15 