### PR TITLE
Use async `mpd_client` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,12 +48,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bufstream"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
@@ -89,6 +94,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "cloudabi"
@@ -309,6 +324,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -538,6 +556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,28 +585,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpd"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a20784da57fa01bf7910a5da686d9f39ff37feaa774856b71f050e4331bf82"
-dependencies = [
- "bufstream",
- "rustc-serialize",
- "time",
-]
-
-[[package]]
 name = "mpd-discord-rpc"
 version = "1.5.1"
 dependencies = [
  "dirs",
  "discord-rpc-client",
  "merge",
- "mpd",
+ "mpd_client",
  "regex",
  "reqwest",
  "serde",
+ "tokio",
  "toml",
+]
+
+[[package]]
+name = "mpd_client"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0126857dd28ede82fd63c913881e0f21586a2148c79d4f96ad620517a474cab9"
+dependencies = [
+ "bytes 1.1.0",
+ "chrono",
+ "futures-core",
+ "mpd_protocol",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "mpd_protocol"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18039a2cd7aa60ebadfe3e759053188def0aef4c036842e645c9ed4490c8ebd3"
+dependencies = [
+ "bytes 1.1.0",
+ "hashbrown",
+ "nom",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -614,12 +655,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -1001,12 +1062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,16 +1230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,7 +1258,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1263,7 +1320,19 @@ checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ keywords = ["mpd", "discord", "rpc", "music", "mopidy"]
 
 [dependencies]
 discord-rpc-client = "0.3.0"
-mpd = "0.0.12"
+mpd_client = "0.7.4"
 dirs = "4.0.0"
 toml = "0.5.9"
 regex = "1.5.6"
 serde = { version = "1.0.137", features = ["derive"] }
 merge = "0.1.0"
 reqwest = { version = "0.11.11", features = ["json", "blocking"] }
+tokio = { version = "1.16.1", features = ["rt"] }
 
 [patch.crates-io]
 discord-rpc-client = { git = "https://github.com/JakeStanger/discord-rpc-client.rs" }

--- a/src/album_art.rs
+++ b/src/album_art.rs
@@ -1,5 +1,6 @@
-// use lazy_static::lazy_static;
-use mpd::Song;
+use crate::mpd_conn::try_get_first_tag;
+use mpd_client::commands::responses::Song;
+use mpd_client::Tag;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -13,13 +14,6 @@ struct SearchResult {
 struct Release {
     id: String,
 }
-
-// lazy_static! {
-//     static ref searchCache: HashMap<(&'static str, &'static str), &'static str> = {
-//         let mut map = HashMap::new();
-//         map
-//     };
-// }
 
 pub struct AlbumArtClient {
     release_cache: HashMap<(String, String), String>,

--- a/src/album_art.rs
+++ b/src/album_art.rs
@@ -85,15 +85,17 @@ impl AlbumArtClient {
     /// Uses MPD's internal MusicBrainz album ID tag if its set,
     /// otherwise falls back to searching.
     pub fn get_album_art_url(&mut self, song: Song) -> Option<String> {
-        let mb_album_id = match song.tags.get("MUSICBRAINZ_ALBUMID") {
-            Some(id) => Some(id.clone()),
+        let mb_album_id = match try_get_first_tag(song.tags.get(&Tag::MusicBrainzReleaseId)) {
+            Some(id) => Some(id.to_string()),
             None => {
                 let tags = song.tags;
-                let artist = tags.get("Artist");
-                let album = tags.get("Album");
+                let artist = try_get_first_tag(tags.get(&Tag::Artist));
+                let album = try_get_first_tag(tags.get(&Tag::Album));
 
                 match (artist, album) {
-                    (Some(artist), Some(album)) => self.find_release(artist.clone(), album.clone()),
+                    (Some(artist), Some(album)) => {
+                        self.find_release(artist.to_string(), album.to_string())
+                    }
                     _ => None,
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
 }
 
 impl Config {
+    /// Merges the user's config into the default config
     fn merge_custom(mut self, other: Config) -> Self {
         self.merge(other.clone());
         let mut format = self.format.unwrap();
@@ -64,6 +65,7 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Gets the path to the config directory
     fn get_dir_path() -> PathBuf {
         let config_dir = config_dir();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,10 +111,10 @@ async fn main() {
                             if !small_image.is_empty() {
                                 assets = assets.small_image(small_image)
                             }
-                            if large_text != "" {
+                            if !large_text.is_empty() {
                                 assets = assets.large_text(large_text)
                             }
-                            if small_text != "" {
+                            if !small_text.is_empty() {
                                 assets = assets.small_text(small_text)
                             }
                             assets

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use std::{thread, time};
 
 use discord_rpc_client::Client as DiscordClient;
-use mpd::{Client as MPDClient, State};
-use regex::{Captures, Regex};
+use mpd_client::commands::responses::{PlayState, Song};
+use mpd_client::{commands, Client as MPDClient};
+use regex::Regex;
 
 use crate::album_art::AlbumArtClient;
 use crate::mpd_conn::get_timestamp;
@@ -16,11 +17,11 @@ mod mpd_conn;
 
 /// Attempts to find a playing MPD host every 5
 /// seconds until one is found
-fn idle(hosts: &[String]) -> MPDClient {
+async fn idle(hosts: &[String]) -> MPDClient {
     println!("Entering idle mode");
 
     loop {
-        let conn_wrapper = mpd_conn::try_get_mpd_conn(hosts);
+        let conn_wrapper = mpd_conn::try_get_mpd_conn(hosts).await;
 
         if let Some(client) = conn_wrapper {
             println!("Exiting idle mode");
@@ -31,7 +32,8 @@ fn idle(hosts: &[String]) -> MPDClient {
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let re = Regex::new(r"\$(\w+)").unwrap();
 
     // Load config and defaults if necessary.
@@ -46,8 +48,8 @@ fn main() {
         timestamp_mode,
         large_image,
         small_image,
-        large_text,
-        small_text,
+        large_text_format,
+        small_text_format,
     ) = (
         format_options.details.as_deref().unwrap(),
         format_options.state.as_deref().unwrap(),
@@ -58,8 +60,13 @@ fn main() {
         format_options.small_text.as_deref().unwrap(),
     );
 
+    let details_tokens = get_tokens(&re, details_format);
+    let state_tokens = get_tokens(&re, state_format);
+    let large_text_tokens = get_tokens(&re, large_text_format);
+    let small_text_tokens = get_tokens(&re, state_format);
+
     // MPD and Discord connections
-    let mut mpd = idle(hosts);
+    let mut mpd = idle(hosts).await;
     let mut drpc = DiscordClient::new(id);
 
     let mut album_art_client = AlbumArtClient::new();
@@ -68,25 +75,22 @@ fn main() {
 
     // Main program loop - keep updating state until exit
     loop {
-        let state = mpd_conn::get_status(&mut mpd).state;
+        let state = mpd_conn::get_status(&mpd).await.state;
 
-        if state == State::Play {
-            if let Ok(Some(song)) = mpd.currentsong() {
-                let details = re.replace_all(details_format, |caps: &Captures| {
-                    mpd_conn::get_token_value(&mut mpd, &song, &caps[1])
-                });
+        if state == PlayState::Playing {
+            let current_song = mpd.command(commands::CurrentSong).await;
+            if let Ok(Some(song_in_queue)) = current_song {
+                let song = song_in_queue.song;
 
-                let state = re.replace_all(state_format, |caps: &Captures| {
-                    mpd_conn::get_token_value(&mut mpd, &song, &caps[1])
-                });
+                let details =
+                    replace_tokens(details_format, &details_tokens, &song, &mut mpd).await;
+                let state = replace_tokens(state_format, &state_tokens, &song, &mut mpd).await;
+                let large_text =
+                    replace_tokens(large_text_format, &large_text_tokens, &song, &mut mpd).await;
+                let small_text =
+                    replace_tokens(small_text_format, &small_text_tokens, &song, &mut mpd).await;
 
-                let large_text = re.replace_all(large_text, |caps: &Captures| {
-                    mpd_conn::get_token_value(&mut mpd, &song, &caps[1])
-                });
-
-                let small_text = re.replace_all(small_text, |caps: &Captures| {
-                    mpd_conn::get_token_value(&mut mpd, &song, &caps[1])
-                });
+                let timestamps = get_timestamp(&mut mpd, timestamp_mode).await;
 
                 let res = drpc.set_activity(|act| {
                     act.state(state)
@@ -115,9 +119,7 @@ fn main() {
                             }
                             assets
                         })
-                        .timestamps(|timestamps| {
-                            get_timestamp(&mut mpd, timestamps, timestamp_mode)
-                        })
+                        .timestamps(|_| timestamps)
                 });
 
                 if let Err(why) = res {
@@ -129,10 +131,33 @@ fn main() {
                 eprintln!("Failed to clear activity: {}", why);
             };
 
-            mpd = idle(hosts);
+            mpd = idle(hosts).await;
         }
 
         // sleep for 1 sec to not hammer the mpd and rpc servers
         thread::sleep(time::Duration::from_secs(ACTIVE_TIME));
     }
+}
+
+/// Extracts the formatting tokens from a formatting string
+fn get_tokens(re: &Regex, format_string: &str) -> Vec<String> {
+    re.captures_iter(format_string)
+        .map(|caps| caps[1].to_string())
+        .collect::<Vec<_>>()
+}
+
+/// Replaces each of the formatting tokens in the formatting string
+/// with actual data pulled from MPD
+async fn replace_tokens(
+    format_string: &str,
+    tokens: &Vec<String>,
+    song: &Song,
+    mpd: &mut MPDClient,
+) -> String {
+    let mut compiled_string = format_string.to_string();
+    for token in tokens {
+        let value = mpd_conn::get_token_value(mpd, song, token).await;
+        compiled_string = compiled_string.replace(format!("${}", token).as_str(), value.as_str());
+    }
+    compiled_string
 }

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -1,20 +1,27 @@
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::net::TcpStream;
 
 use discord_rpc_client::models::ActivityTimestamps;
-use mpd::{Client as MPDClient, Song, State, Status};
+use mpd_client::commands::responses::{PlayState, Song, Status};
+use mpd_client::{commands, Client as MPDClient, Tag};
 
 /// Cycles through each MPD host and
 /// returns the first one which is playing,
 /// or none if one is not found.
-pub(crate) fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
+pub(crate) async fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
     for host in hosts {
-        match MPDClient::connect(host) {
-            Ok(mut conn) => {
-                let state = get_status(&mut conn).state;
-                if state == State::Play {
-                    return Some(conn);
+        let connection = TcpStream::connect(host).await;
+        match connection {
+            Ok(conn) => match MPDClient::connect(conn).await {
+                Ok(conn) => {
+                    let client = conn.0;
+                    let state = get_status(&client).await.state;
+                    if state == PlayState::Playing {
+                        return Some(client);
+                    }
                 }
-            }
+                Err(why) => eprintln!("Error connecting to {}: {}", host, why),
+            },
             Err(why) => eprintln!("Error connecting to {}: {}", host, why),
         }
     }
@@ -23,8 +30,8 @@ pub(crate) fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
 }
 
 /// Formats a duration given in seconds
-// in hh:mm format
-fn format_time(time: i64) -> String {
+/// in hh:mm format
+fn format_time(time: u64) -> String {
     let minutes = (time / 60) % 60;
     let seconds = time % 60;
 
@@ -33,34 +40,34 @@ fn format_time(time: i64) -> String {
 
 /// Converts a string format token value
 /// into its respective MPD value.
-pub(crate) fn get_token_value(client: &mut MPDClient, song: &Song, token: &str) -> String {
+pub(crate) async fn get_token_value(client: &mut MPDClient, song: &Song, token: &str) -> String {
     let s = match token {
-        "title" => song.title.as_ref(),
-        "album" => song.tags.get("Album"),
-        "artist" => song.tags.get("Artist"),
-        "date" => song.tags.get("Date"),
-        "disc" => song.tags.get("Disc"),
-        "genre" => song.tags.get("Genre"),
-        "track" => song.tags.get("Track"),
-        "duration" => return format_time(get_time(&get_status(client))),
-        "elapsed" => return format_time(get_elapsed(&get_status(client))),
+        "title" => song.title(),
+        "album" => try_get_first_tag(song.tags.get(&Tag::Album)),
+        "artist" => try_get_first_tag(song.tags.get(&Tag::Artist)),
+        "date" => try_get_first_tag(song.tags.get(&Tag::Date)),
+        "disc" => try_get_first_tag(song.tags.get(&Tag::Disc)),
+        "genre" => try_get_first_tag(song.tags.get(&Tag::Genre)),
+        "track" => try_get_first_tag(song.tags.get(&Tag::Track)),
+        "duration" => return format_time(get_duration(&get_status(client).await)),
+        "elapsed" => return format_time(get_elapsed(&get_status(client).await)),
         _ => return token.to_string(),
     };
-    s.cloned().unwrap_or_default()
+    s.unwrap_or_default().to_string()
 }
 
-pub(crate) fn get_timestamp(
-    client: &mut MPDClient,
-    timestamps: ActivityTimestamps,
-    mode: &str,
-) -> ActivityTimestamps {
+/// Gets the activity timestamp based off the current song elapsed/remaining
+pub(crate) async fn get_timestamp(client: &mut MPDClient, mode: &str) -> ActivityTimestamps {
     let current_time = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    let status = get_status(client);
+
+    let status = get_status(client).await;
 
     let elapsed = get_elapsed(&status);
+
+    let timestamps = ActivityTimestamps::new();
 
     match mode {
         "left" => {
@@ -76,28 +83,34 @@ pub(crate) fn get_timestamp(
 
 /// Gets MPD server status.
 /// Panics on error.
-pub(crate) fn get_status(client: &mut MPDClient) -> Status {
-    client.status().expect("Failed to get MPD server status")
+pub(crate) async fn get_status(client: &MPDClient) -> Status {
+    client
+        .command(commands::Status)
+        .await
+        .expect("Failed to get MPD server status")
 }
 
-fn get_time(status: &Status) -> i64 {
-    status
-        .time
-        .expect("Failed to get duration (time) from MPD status")
-        .1
-        .num_seconds()
+/// Attempts to read the first value for a tag
+/// (since the MPD client returns a vector of tags, or None)
+pub(crate) fn try_get_first_tag(vec: Option<&Vec<String>>) -> Option<&str> {
+    match vec {
+        Some(vec) => vec.first().map(|val| val.as_str()),
+        None => None,
+    }
 }
 
-fn get_duration(status: &Status) -> i64 {
+/// Gets the duration of the current song
+fn get_duration(status: &Status) -> u64 {
     status
         .duration
         .expect("Failed to get duration from MPD status")
-        .num_seconds()
+        .as_secs()
 }
 
-fn get_elapsed(status: &Status) -> i64 {
+/// Gets the elapsed time of the current song
+fn get_elapsed(status: &Status) -> u64 {
     status
         .elapsed
         .expect("Failed to get elapsed time from MPD status")
-        .num_seconds()
+        .as_secs()
 }


### PR DESCRIPTION
Use a different MPD client crate. This one is better maintained and also async, which involved quite a bit of refactoring.

This doesn't serve much benefit but it was a good way to experiment with the crate.

- Fixes #8.
- Closes #13 as the new MPD client makes this no longer relevant.