### PR TITLE
fix unix sockets detection

### DIFF
--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -6,6 +6,7 @@ use discord_rpc_client::models::ActivityTimestamps;
 use mpd_client::commands::responses::{PlayState, Song, Status};
 use mpd_client::raw::MpdProtocolError;
 use mpd_client::{commands, Client as MPDClient, Connection, Tag};
+use std::os::unix::fs::FileTypeExt;
 
 /// Cycles through each MPD host and
 /// returns the first one which is playing,
@@ -34,7 +35,10 @@ pub(crate) async fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
 }
 
 fn is_unix_socket(host: &String) -> bool {
-    PathBuf::from(host).is_file()
+    match PathBuf::from(host).metadata() {
+        Ok(metadata) => metadata.file_type().is_socket(),
+        Err(_) => false,
+    }
 }
 
 async fn connect_unix(host: &String) -> Result<Connection, MpdProtocolError> {

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -35,7 +35,8 @@ pub(crate) async fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
 }
 
 fn is_unix_socket(host: &String) -> bool {
-    match PathBuf::from(host).metadata() {
+    let path = PathBuf::from(host);
+    path.exists() && match path.metadata() {
         Ok(metadata) => metadata.file_type().is_socket(),
         Err(_) => false,
     }

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -36,10 +36,11 @@ pub(crate) async fn try_get_mpd_conn(hosts: &[String]) -> Option<MPDClient> {
 
 fn is_unix_socket(host: &String) -> bool {
     let path = PathBuf::from(host);
-    path.exists() && match path.metadata() {
-        Ok(metadata) => metadata.file_type().is_socket(),
-        Err(_) => false,
-    }
+    path.exists()
+        && match path.metadata() {
+            Ok(metadata) => metadata.file_type().is_socket(),
+            Err(_) => false,
+        }
 }
 
 async fn connect_unix(host: &String) -> Result<Connection, MpdProtocolError> {


### PR DESCRIPTION
`is_file` method from `PathBuf` checks if the path exists and point's to a regular file, which UNIX sockets are not. This PR checks if the file is a socket using `Metadata`.

Maybe the error can be handled a bit better but I barely know any rust, and this change makes it work in my machine so yeah