### PR TITLE
Add support for Album Artist tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following will automatically be replaced with their value from MPD:
 - `$title`
 - `$album`
 - `$artist`
+- `$albumartist`
 - `$date`
 - `$track`
 - `$disc`

--- a/src/album_art.rs
+++ b/src/album_art.rs
@@ -128,7 +128,8 @@ impl AlbumArtClient {
 
     fn get_cache_key(song: &Song) -> Option<(String, String)> {
         let tags = &song.tags;
-        let artist = try_get_first_tag(tags.get(&Tag::AlbumArtist)).or(try_get_first_tag(tags.get(&Tag::Artist)));
+        let artist = try_get_first_tag(tags.get(&Tag::AlbumArtist))
+            .or(try_get_first_tag(tags.get(&Tag::Artist)));
         let album = try_get_first_tag(tags.get(&Tag::Album));
 
         match (artist, album) {

--- a/src/album_art.rs
+++ b/src/album_art.rs
@@ -128,7 +128,7 @@ impl AlbumArtClient {
 
     fn get_cache_key(song: &Song) -> Option<(String, String)> {
         let tags = &song.tags;
-        let artist = try_get_first_tag(tags.get(&Tag::Artist));
+        let artist = try_get_first_tag(tags.get(&Tag::AlbumArtist)).or(try_get_first_tag(tags.get(&Tag::Artist)));
         let album = try_get_first_tag(tags.get(&Tag::Album));
 
         match (artist, album) {

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -20,6 +20,7 @@ pub fn get_token_value(song: &Song, status: &Status, token: &str) -> String {
         "title" => song.title(),
         "album" => try_get_first_tag(song.tags.get(&Tag::Album)),
         "artist" => try_get_first_tag(song.tags.get(&Tag::Artist)),
+        "album_artist" => try_get_first_tag(song.tags.get(&Tag::AlbumArtist)),
         "date" => try_get_first_tag(song.tags.get(&Tag::Date)),
         "disc" => try_get_first_tag(song.tags.get(&Tag::Disc)),
         "genre" => try_get_first_tag(song.tags.get(&Tag::Genre)),

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -20,7 +20,7 @@ pub fn get_token_value(song: &Song, status: &Status, token: &str) -> String {
         "title" => song.title(),
         "album" => try_get_first_tag(song.tags.get(&Tag::Album)),
         "artist" => try_get_first_tag(song.tags.get(&Tag::Artist)),
-        "album_artist" => try_get_first_tag(song.tags.get(&Tag::AlbumArtist)),
+        "albumartist" => try_get_first_tag(song.tags.get(&Tag::AlbumArtist)),
         "date" => try_get_first_tag(song.tags.get(&Tag::Date)),
         "disc" => try_get_first_tag(song.tags.get(&Tag::Disc)),
         "genre" => try_get_first_tag(song.tags.get(&Tag::Genre)),


### PR DESCRIPTION
Album artists are more strongly associated with a release group. This PR adds two functionalities:

1. Allow entering  `$albumartist` in config.toml to show the AlbumArtist tag.

2. When looking up album art, use the AlbumArtist tag if it exists, otherwise the Artist tag.