### PR TITLE
build(deps): bump discord_presence from 1.1.2 to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "discord-presence"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8809aaa2b59ac479f5f0030b67f2b9c4041b205670b60790a631554e8a4661b"
+checksum = "01861d3847a00dfb89f9e064c45823bffae9d3d49c32c5b21ada7001fb08769e"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["mpd", "discord", "rpc", "music", "mopidy"]
 
 [dependencies]
-discord-presence = "1.1.2"
+discord-presence = "1.2.0"
 mpd_client = "1.4.1"
 dirs = "5.0.1"
 toml = "0.8.12"


### PR DESCRIPTION
Update the `discord_presence` crate to make use of [#102](https://github.com/jewlexx/discord-presence/pull/102).

This will prevent the service from pinning a thread to 100% while Discord isn't running.