### PR TITLE
Change activity type to 'listening' instead of 'playing'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "quork",
  "serde",
  "serde_json",
+ "serde_repr",
  "thiserror",
  "tracing",
  "uuid",
@@ -1282,6 +1283,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["mpd", "discord", "rpc", "music", "mopidy"]
 
 [dependencies]
-discord-presence = "1.3.1"
+discord-presence = {version = "1.3.1", features = ["activity_type"]}
 mpd_client = "1.4.1"
 dirs = "5.0.1"
 toml = "0.8.19"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use discord_presence::models::EventData;
+use discord_presence::models::ActivityType;
 use discord_presence::{Client as DiscordClient, DiscordError};
 use mpd_client::client::ConnectionEvent::SubsystemChange;
 use mpd_client::client::Subsystem;
@@ -186,6 +187,7 @@ impl<'a> Service<'a> {
 
                 let res = self.drpc.set_activity(|act| {
                     act.state(state)
+                        ._type(ActivityType::Listening)
                         .details(details)
                         .assets(|mut assets| {
                             match url {


### PR DESCRIPTION
it would be interesting if this were an option in the settings to change it, I still don't know rust, so I'll leave that to you.

ps: even with the activity_type feature, the “type” alias doesn't exist so I used “_type”
ps 2: activity_type feature is still required.