### PR TITLE
feat: timestamp "both" mode, progress bar

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,11 +8,12 @@ pub enum TimestampMode {
     Elapsed,
     Left,
     Off,
+    Both,
 }
 
 impl Default for TimestampMode {
     fn default() -> Self {
-        Self::Elapsed
+        Self::Both
     }
 }
 

--- a/src/mpd_conn.rs
+++ b/src/mpd_conn.rs
@@ -40,7 +40,7 @@ pub fn get_timestamp(status: &Status, mode: TimestampMode) -> ActivityTimestamps
         .expect("Failed to get system time")
         .as_secs();
 
-    let timestamps = ActivityTimestamps::new();
+    let mut timestamps = ActivityTimestamps::new();
 
     let Some(elapsed) = get_elapsed(status) else {
         return timestamps;
@@ -51,15 +51,21 @@ pub fn get_timestamp(status: &Status, mode: TimestampMode) -> ActivityTimestamps
             let Some(duration) = get_duration(status) else {
                 return timestamps;
             };
-
             let remaining = duration - elapsed;
             timestamps.end(current_time + remaining)
         }
         TimestampMode::Off => timestamps,
         TimestampMode::Elapsed => timestamps.start(current_time - elapsed),
+        TimestampMode::Both => {
+            let Some(duration) = get_duration(status) else {
+                return timestamps;
+            };
+            let start_timestamp = current_time - elapsed;
+            let end_timestamp = start_timestamp + duration;
+            timestamps.start(start_timestamp).end(end_timestamp)
+        }
     }
 }
-
 /// Attempts to read the first value for a tag
 /// (since the MPD client returns a vector of tags, or None)
 pub fn try_get_first_tag(vec: Option<&Vec<String>>) -> Option<&str> {


### PR DESCRIPTION
implements a "both" mode for the timestamp setting, which sends both the start time and the end time of the song, which creates a progress bar on Discord:

![image](https://github.com/user-attachments/assets/8a07d651-13d7-436e-9ea1-c20329d66ca6)

Also set it as the default, as I think it's the most sane option.