### PR TITLE
fix: stop calling `DiscordClient::start()` when error is thrown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use mpd_client::responses::{PlayState, Song, SongInQueue, Status};
 use mpd_utils::MultiHostClient;
 use regex::Regex;
 use tokio::sync::mpsc;
-use tokio::time::sleep;
 use tracing::{debug, error, info};
 
 use crate::album_art::AlbumArtClient;
@@ -96,11 +95,7 @@ async fn main() {
                         service.update_state(&status, current_song).await;
                     }
                     },
-                    ServiceEvent::Error(err) => {
-                        error!("{err}");
-                        sleep(Duration::from_secs(IDLE_TIME)).await;
-                        service.start();
-                    }
+                    ServiceEvent::Error(err) => error!("{err}"),
                 }
             },
         }


### PR DESCRIPTION
Closes: https://github.com/JakeStanger/mpd-discord-rpc/issues/204

DiscordClient::start() will attempt to reconnect automatically, calling it manually is allowed for some reason and spawns additional threads.

Tested briefly - closed and opened Discord client around 5 times while running, reconnects automatically, no issues, additional threads are no longer spawned. 