### PR TITLE
fix: create drpc client with error config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,16 +62,16 @@ async fn main() {
                     debug!("Change: {event:?}");
 
                     if let Ok((Some(status), current_song)) = mpd.with_client(|client| async move {
-                            let status = client.command(commands::Status).await.ok();
+                        let status = client.command(commands::Status).await.ok();
 
-                            let current_song = if status.is_some() {
-                                client.command(commands::CurrentSong).await.ok().flatten()
-                            } else {
-                                None
-                            };
+                        let current_song = if status.is_some() {
+                            client.command(commands::CurrentSong).await.ok().flatten()
+                        } else {
+                            None
+                        };
 
-                            (status, current_song)
-                        }).await {
+                        (status, current_song)
+                    }).await {
                         service.update_state(&status, current_song).await;
                     }
                 }
@@ -93,8 +93,8 @@ async fn main() {
 
                             (status, current_song)
                         }).await {
-                        service.update_state(&status, current_song).await;
-                    }
+                            service.update_state(&status, current_song).await;
+                        }
                     },
                     ServiceEvent::Error(err) => {
                         error!("{err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,8 @@ impl<'a> Service<'a> {
         let event_tx3 = event_tx.clone();
         let event_tx4 = event_tx.clone();
 
-        let drpc = DiscordClient::new(config.id);
+        let drpc =
+            DiscordClient::with_error_config(config.id, Duration::from_secs(IDLE_TIME), Some(0));
 
         drpc.on_ready(move |_| {
             info!("discord rpc ready");


### PR DESCRIPTION
Fixes https://github.com/JakeStanger/mpd-discord-rpc/issues/204

Creating the drpc client with `DiscordClient::with_error_config()` and 0 attempts makes the spawned threads actually exit on error and not persist to keep retrying.

Tested a few cases where I observed the issue, starting with discord opened, closed, before and after the socket is created, no extra threads persist and connection is consistent.
Will continue using as my main service to check if behavior changes.